### PR TITLE
Update dependencies for mapr 6.0.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ are using.  This is under the dependency for `com.mapr.db`:
       <dependency>
         <groupId>com.mapr.db</groupId>
         <artifactId>maprdb</artifactId>
-        <version>5.2.1-mapr</version>
+        <version>6.0.0-mapr</version>
       </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.mapr.db</groupId>
       <artifactId>maprdb</artifactId>
-      <version>5.2.1-mapr</version>
+      <version>6.0.0-mapr</version>
     </dependency>
   </dependencies>
 

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ if len(glob.glob(dependencies_dir)) == 0:  # __init__.py
 
 setup(
     name = "maprdb",
-    version = "0.0.3",
-    description = ("API to work with MapR DB. Wrapper of Java API."),
+    version = "0.0.4",
+    description = ("API to work with MapR DB 6.0.0. Wrapper of Java API."),
     license = "Apache License 2.0",
     keywords = "mapr db json",
     packages=["maprdb", "maprdb.dependency"],


### PR DESCRIPTION
Pip package available in public pypi repos is outdated (still pointing to 5.2.1). 
Now that 6.0.0 is out, it would be useful to have an updated public pip package available. https://pypi.python.org/pypi/maprdb 